### PR TITLE
Fixes the button borders on Safari

### DIFF
--- a/lib/terminal.css
+++ b/lib/terminal.css
@@ -617,6 +617,8 @@ select:-webkit-autofill:focus {
 }
 
 .btn {
+  border-style: solid;
+  border-width: 1px;
   display: -ms-inline-flexbox;
   display: inline-flex;
   -ms-flex-align: center;


### PR DESCRIPTION
This should fix issue #12.

I tried it on Safari but I don't have a Windows install of Vivaldi on hand to try it there.