### PR TITLE
Document: Show default values of variables, with color previews

### DIFF
--- a/templates/partials/documentation.html
+++ b/templates/partials/documentation.html
@@ -17,42 +17,65 @@
                     font-style: italic;
                 }
 
+                .custom-dl .color-preview {
+                    width: 12px;
+                    height: 12px;
+                    display: inline-block;
+                    outline: #000 solid 1px;
+                    margin-right: 4px;
+                }
             </style>
             <dt>--global-font-size</dt>
             <dd>The Base font size</dd>
+            <dd class="italic">(Default: <code>15px</code>)</dd>
             <dt>--global-line-height</dt>
             <dd>The baseline height. Modify this to achieve the best readability.</dd>
+            <dd class="italic">(Default: <code>1.4em</code>)</dd>
             <dt>--font-stack</dt>
             <dd>The fonts for the website.</dd>
             <dd>Use <code>@font-face</code> or any other font provider to include your custom fonts.</dd>
+            <dd class="italic">(Default: <code>"Menlo", "Monaco", "Lucida Console", "Liberation Mono", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Courier New", serif</code>)</dd>
             <dt>--mono-font-stack</dt>
             <dd>Same as above but for <code>code</code>.</dd>
+            <dd class="italic">(Default: <code>"Menlo", "Monaco", "Lucida Console", "Liberation Mono", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Courier New", serif</code>)</dd>
             <dt>--background-color</dt>
             <dd>The page background color</dd>
+            <dd class="italic">(Default: <code><span class="color-preview" style="background-color: var(--background-color);"></span>#fff</code>)</dd>
             <dt>--font-color</dt>
             <dd>The base font color for text, headlines, blockquotes, lists, etc.</dd>
+            <dd class="italic">(Default: <code><span class="color-preview" style="background-color: var(--font-color);"></span>#151515</code>)</dd>
             <dt>--invert-font-color</dt>
             <dd>Sometimes text appears on a colored background. Adjust this color to improve readability.</dd>
+            <dd class="italic">(Default: <code><span class="color-preview" style="background-color: var(--invert-font-color);"></span>#fff</code>)</dd>
             <dt>--primary-color</dt>
             <dd>The primary color is used for links and buttons.</dd>
+            <dd class="italic">(Default: <code><span class="color-preview" style="background-color: var(--primary-color);"></span>#1a95e0</code>)</dd>
             <dt>--secondary-color</dt>
             <dd>The secondary color is more subtle than the primary color. It's used for code highlighting and image captions.</dd>
+            <dd class="italic">(Default: <code><span class="color-preview" style="background-color: var(--secondary-color);"></span>#727578</code>)</dd>
             <dt>--error-color</dt>
             <dd>Used for error alerts and form validation.</dd>
+            <dd class="italic">(Default: <code><span class="color-preview" style="background-color: var(--error-color);"></span>#d20962</code>)</dd>
             <dt>--progress-bar-background</dt>
             <dd>The background color of progress bars.</dd>
+            <dd class="italic">(Default: <code><span class="color-preview" style="background-color: var(--progress-bar-background);"></span>#727578</code>)</dd>
             <dt>--progress-bar-fill</dt>
             <dd>The fill color, indicating the progress in progress bars.</dd>
+            <dd class="italic">(Default: <code><span class="color-preview" style="background-color: var(--progress-bar-fill);"></span>#151515</code>)</dd>
             <dt>--code-bg-color</dt>
             <dd>The background color of <code>&lt;code&gt;</code> elements.</dd>
+            <dd class="italic">(Default: <code><span class="color-preview" style="background-color: var(--code-bg-color);"></span>#e8eff2</code>)</dd>
             <dt>--block-background-color</dt>
             <dd>The background color of <code>&lt;pre&gt;</code> elements. Also applies to <code>&lt;code&gt;</code> elements inside a <code>&lt;pre&gt;</code> element.</dd>
+            <dd class="italic">(Default: <code><span class="color-preview" style="background-color: var(--block-background-color);"></span>#fff</code>)</dd>
             <dt>--input-style</dt>
             <dd>The style of input element borders. Possible values are:</dd>
             <dd class="italic">none, solid, dotted, dashed, double, groove, ridge, inset, outset, hidden, inherit, initial, unset</dd>
+            <dd class="italic">(Default: <code>solid</code>)</dd>
             <dt>--display-h1-decoration</dt>
             <dd>Show a double dash below <code>h1</code> elements. Possible values are:</dd>
             <dd class="italic">block, none</dd>
+            <dd class="italic">(Default: <code>none</code>)</dd>
         </dl>
     </section>
     <hr>


### PR DESCRIPTION
Default values are wrapped in `<dd class="italic">`.
Shows color values with preview box(`<span class="color-preview">`).
Color previews are inline-styled using `--var()`.

Preview:
<img width="639" alt="terminal.css document of css variables, with default values written" src="https://user-images.githubusercontent.com/17811025/150621937-c7a9cca4-4e4e-4c9d-8182-14b87626bd04.png">
