### PR TITLE
Fix blockquote empty overhang

### DIFF
--- a/lib/terminal.css
+++ b/lib/terminal.css
@@ -160,7 +160,7 @@ blockquote::after {
   color: #9ca2ab;
 }
 
-blockquote *:last-child {
+blockquote > *:last-child {
   margin-bottom: 0;
 }
 

--- a/lib/terminal.css
+++ b/lib/terminal.css
@@ -160,6 +160,10 @@ blockquote::after {
   color: #9ca2ab;
 }
 
+blockquote *:last-child {
+  margin-bottom: 0;
+}
+
 code {
   font-weight: inherit;
   background-color: var(--code-bg-color);


### PR DESCRIPTION
When the blockquote element only contains a p element but no footer
element or similar trailing tag, the ::after pseudo class paints a
trailing empty line which only contains the ">" character. This is
caused by an overhanging paragraph margin. Removing the margin for any
last element contained in blockquote removes this visual glitch.