### PR TITLE
🎨 style(terminal.css): add gap property to .terminal-nav to improve layout spacing and alignment

### DIFF
--- a/lib/terminal.css
+++ b/lib/terminal.css
@@ -836,6 +836,7 @@ select:-webkit-autofill:focus {
   .terminal-nav {
     flex-direction: row;
     align-items: center;
+    gap: 100vh;
   }
 
   .terminal-menu ul {


### PR DESCRIPTION
Problem:
when adding flex property to the body element to the fixed footer in the bottom, the navbar is broken.

Solution:
add gap property to .terminal-nav to improve layout spacing and alignment

Close #44 