### PR TITLE
Fix typo in highlight-js partial

### DIFF
--- a/templates/partials/highlight-js.html
+++ b/templates/partials/highlight-js.html
@@ -1,7 +1,7 @@
 <section>
     <header>
         <h2 id="highlightjs">Supports Highlight.js</h2>
-        <p>Terminal CSS comes with a build in theme for <a href="https://highlightjs.org/" target="_black" rel="noopener noreferrer">Highlight.js</a></p>
+        <p>Terminal CSS comes with a built in theme for <a href="https://highlightjs.org/" target="_black" rel="noopener noreferrer">Highlight.js</a></p>
     </header>
 <pre>
 <code>


### PR DESCRIPTION
Fixed a typo in the Highlight.js section ('build' to 'built').